### PR TITLE
Gradle-build repariert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ compileJava {
 }
 compileJava << {
 	Properties props = new Properties()
-	File propsFile = new File('src/main/resources/version.properties')
+	File propsFile = file('src/main/resources/version.properties').absoluteFile
 	props.load(propsFile.newDataInputStream())
 	
 	println '==msearch======================'


### PR DESCRIPTION
Wenn der Build von einem der Hauptprojekte gestartet wird (wie bei travis), ist das lokale Verzeichnis falsch und `version.properties` wird nicht gefunden.