### PR TITLE
Vorschlag: Hotfix/#52 (version.properties) mit git-describe als Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/javadoc
 /nbproject/private/
 .externalToolBuilders
 .idea
+version.properties

--- a/build.gradle
+++ b/build.gradle
@@ -57,13 +57,16 @@ def loadVersionProperties() {
 
 task updateVersion << {
     Properties props = loadVersionProperties()
+    String buildDate = new Date().format('dd.MM.yyyy HH:mm:ss')
     def oldVersion = props.getProperty('VERSION')
     def newVersion = grgit.describe();
     if(!oldVersion.equals(newVersion)){
 	logger.lifecycle "==MSearch======================"
 	logger.lifecycle "Version: ${newVersion}"
+	logger.lifecycle "Datum  : ${buildDate}"
 	logger.lifecycle "==MSearch======================"
 	props.setProperty('VERSION', newVersion)
+	props.setProperty('DATE', buildDate)
 	props.store(propsFile.newWriter(), null)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'application'
 apply from: "${project.rootDir}/gradle/eclipse.gradle"
+import java.nio.file.Files
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -38,6 +39,10 @@ dependencies {
 
 ext {
     propsFile = file('src/main/resources/version.properties').absoluteFile
+    if(!propsFile.exists())
+    {
+    	Files.createFile(propsFile.toPath())
+    }
 }
 
 def loadVersionProperties() {
@@ -48,8 +53,8 @@ def loadVersionProperties() {
 
 task updateVersion << {
     Properties props = loadVersionProperties()
-    oldVersion = props.getProperty('VERSION')
-    if(!oldVersion.equals($project.version)){
+    def oldVersion = props.getProperty('VERSION')
+    if(!oldVersion.equals(project.version)){
 	logger.lifecycle "==msearch======================"
 	logger.lifecycle "Version: $project.version"
 	logger.lifecycle "==msearch======================"

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,30 @@ dependencies {
     compile 'org.tukaani:xz:1.5'
 }
 
+ext {
+    propsFile = file('src/main/resources/version.properties').absoluteFile
+}
+
+def loadVersionProperties() {
+    Properties props = new Properties()
+    props.load(propsFile.newDataInputStream())
+    return props
+}
+
+task updateVersion << {
+    Properties props = loadVersionProperties()
+    oldVersion = props.getProperty('VERSION')
+    if(!oldVersion.equals($project.version)){
+	logger.lifecycle "==msearch======================"
+	logger.lifecycle "Version: $project.version"
+	logger.lifecycle "==msearch======================"
+	props.setProperty('VERSION', project.version)	
+	props.store(propsFile.newWriter(), null)
+    }
+}
+
+processResources.dependsOn updateVersion
+
 distributions {
     main {
         baseName = 'MSearch'

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,16 @@
+plugins {
+  id "org.ajoberstar.grgit" version "1.6.0"
+}
+
 apply plugin: 'java'
 apply plugin: 'application'
 apply from: "${project.rootDir}/gradle/eclipse.gradle"
+
 import java.nio.file.Files
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 mainClassName = 'mSearch.Main'
-version = '2.0.1'
 
 compileJava {
     options.encoding = "UTF-8"
@@ -54,11 +58,12 @@ def loadVersionProperties() {
 task updateVersion << {
     Properties props = loadVersionProperties()
     def oldVersion = props.getProperty('VERSION')
-    if(!oldVersion.equals(project.version)){
-	logger.lifecycle "==msearch======================"
-	logger.lifecycle "Version: $project.version"
-	logger.lifecycle "==msearch======================"
-	props.setProperty('VERSION', project.version)	
+    def newVersion = grgit.describe();
+    if(!oldVersion.equals(newVersion)){
+	logger.lifecycle "==MSearch======================"
+	logger.lifecycle "Version: ${newVersion}"
+	logger.lifecycle "==MSearch======================"
+	props.setProperty('VERSION', newVersion)
 	props.store(propsFile.newWriter(), null)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,34 +41,21 @@ dependencies {
     compile 'org.tukaani:xz:1.5'
 }
 
-ext {
-    propsFile = file('src/main/resources/version.properties').absoluteFile
-    if(!propsFile.exists())
-    {
-    	Files.createFile(propsFile.toPath())
-    }
-}
+task updateVersion {
 
-def loadVersionProperties() {
     Properties props = new Properties()
-    props.load(propsFile.newDataInputStream())
-    return props
-}
-
-task updateVersion << {
-    Properties props = loadVersionProperties()
     String buildDate = new Date().format('dd.MM.yyyy HH:mm:ss')
-    def oldVersion = props.getProperty('VERSION')
-    def newVersion = grgit.describe();
-    if(!oldVersion.equals(newVersion)){
-	logger.lifecycle "==MSearch======================"
-	logger.lifecycle "Version: ${newVersion}"
-	logger.lifecycle "Datum  : ${buildDate}"
-	logger.lifecycle "==MSearch======================"
-	props.setProperty('VERSION', newVersion)
+    def version = grgit.describe();
+    def propsFile = file('src/main/resources/version.properties')
+
+	props.setProperty('VERSION', version)
 	props.setProperty('DATE', buildDate)
 	props.store(propsFile.newWriter(), null)
-    }
+
+	logger.lifecycle "==MSearch======================"
+	logger.lifecycle "Version: ${version}"
+	logger.lifecycle "Datum  : ${buildDate}"
+	logger.lifecycle "==MSearch======================"
 }
 
 processResources.dependsOn updateVersion

--- a/src/main/java/mSearch/Const.java
+++ b/src/main/java/mSearch/Const.java
@@ -23,7 +23,6 @@ import mSearch.tool.Functions;
 
 public class Const {
 
-    public static final String VERSION = "13";
     public static final String VERSION_FILMLISTE = "3";
     public static final String PROGRAMMNAME = "MSearch";
     public static final String USER_AGENT_DEFAULT = Const.PROGRAMMNAME + Functions.getProgVersionString();

--- a/src/main/java/mSearch/tool/Functions.java
+++ b/src/main/java/mSearch/tool/Functions.java
@@ -128,8 +128,32 @@ public class Functions {
     }
 
     public static String getProgVersionString() {
-        return " [Rel: " + getBuildNr() + "]";
+        return " [Rel: " + getProgVersion() + "]";
     }
+
+    public static String getProgVersion(){
+        final ResourceBundle rb;
+        String propToken = "VERSION";
+        String msg = "";
+        try {
+            ResourceBundle.clearCache();
+            rb = ResourceBundle.getBundle("version-mv");
+            msg = rb.getString(propToken);
+        } catch (Exception e) {
+            Log.errorLog(807293848, "Versions-Ressource für MediathekView nicht gefunden!");
+        }
+        return msg;
+    }
+
+   public static String getProgVersionMajor(){
+
+       // 2.0.1-7-ge04f367 -> "2.0.1" -> "2"
+
+       String describeVersion = getProgVersion();
+       String[] split = describeVersion.split("[\\.-]");
+       return split[0];
+   }
+
 
     public static String[] getJavaVersion() {
         String[] ret = new String[4];
@@ -150,24 +174,24 @@ public class Functions {
             rb = ResourceBundle.getBundle("version");
             msg = rb.getString(propToken);
         } catch (Exception e) {
-            Log.errorLog(807293847, e);
+            Log.errorLog(807293847, "Versions-Ressource nicht gefunden!");
         }
         return msg;
     }
 
-    public static String getBuildNr() {
-        final ResourceBundle rb;
-        String propToken = "BUILD";
-        String msg = "";
-        try {
-            ResourceBundle.clearCache();
-            rb = ResourceBundle.getBundle("version");
-            msg = rb.getString(propToken);
-        } catch (Exception e) {
-            Log.errorLog(134679898, e);
-        }
-        return msg;
-    }
+    //public static String getBuildNr() {
+    //    final ResourceBundle rb;
+    //    String propToken = "BUILD";
+    //    String msg = "";
+    //    try {
+    //        ResourceBundle.clearCache();
+    //        rb = ResourceBundle.getBundle("version");
+    //        msg = rb.getString(propToken);
+    //    } catch (Exception e) {
+    //        Log.errorLog(134679898, e);
+    //    }
+    //    return msg;
+    //}
 
     public static void unescape(DatenFilm film) {
         film.arr[DatenFilm.FILM_THEMA] = StringEscapeUtils.unescapeXml(film.arr[DatenFilm.FILM_THEMA].trim());


### PR DESCRIPTION
#52 
Ich würde vorschlagen [git-describe](https://git-scm.com/docs/git-describe#_examples) für die Version zu nutzen. Dazu habe ich in die `build.gradle` [grgit](https://github.com/ajoberstar/grgit) aufgenommen, um da ran zu komm' und den `updateVersion` Task etwas angepasst.
Da die `version.properties` sich so zuverlässig, ohne Zuarbeit, generieren lässt, kann sie auch in `.gitignore` bleiben und kann so ruhig ohne Prüfung überschrieben werden.

Wenn das so okay ist, stell' ich noch ne PR gegen `master`.