### PR TITLE
Buildnummer komplett entfernt. …

### DIFF
--- a/src/main/java/mSearch/Const.java
+++ b/src/main/java/mSearch/Const.java
@@ -23,7 +23,7 @@ import mSearch.tool.Functions;
 
 public class Const {
 
-    public static final String VERSION = "13";
+    public static final String VERSION = "13"; //Obsolet
     public static final String VERSION_FILMLISTE = "3";
     public static final String PROGRAMMNAME = "MSearch";
     public static final String USER_AGENT_DEFAULT = Const.PROGRAMMNAME + Functions.getProgVersionString();

--- a/src/main/java/mSearch/Const.java
+++ b/src/main/java/mSearch/Const.java
@@ -23,7 +23,7 @@ import mSearch.tool.Functions;
 
 public class Const {
 
-    public static final String VERSION = "13"; //Obsolet
+    @Deprecated public static final String VERSION = "13";
     public static final String VERSION_FILMLISTE = "3";
     public static final String PROGRAMMNAME = "MSearch";
     public static final String USER_AGENT_DEFAULT = Const.PROGRAMMNAME + Functions.getProgVersionString();

--- a/src/main/java/mSearch/tool/FilenameUtils.java
+++ b/src/main/java/mSearch/tool/FilenameUtils.java
@@ -8,7 +8,6 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
-import static mSearch.tool.Functions.OperatingSystemType.*;
 
 /**
  * User: crystalpalace1977

--- a/src/main/java/mSearch/tool/Functions.java
+++ b/src/main/java/mSearch/tool/Functions.java
@@ -28,6 +28,8 @@ import mSearch.daten.DatenFilm;
 import org.apache.commons.lang3.StringEscapeUtils;
 
 public class Functions {
+	
+	private static final ResourceBundle rbversion = ResourceBundle.getBundle("version");
 
     public static String textLaenge(int max, String text, boolean mitte, boolean addVorne) {
         if (text.length() > max) {
@@ -142,14 +144,12 @@ public class Functions {
     }
 
     public static String getCompileDate() {
-        final ResourceBundle rb;
         String propToken = "DATE";
         String msg = "";
         try {
             ResourceBundle.clearCache();
-            rb = ResourceBundle.getBundle("version");
-            if (rb.containsKey(propToken)) {
-                msg = rb.getString(propToken);
+            if (rbversion.containsKey(propToken)) {
+                msg = rbversion.getString(propToken);
             }
         } catch (Exception e) {
             Log.errorLog(807293847, e);
@@ -158,13 +158,11 @@ public class Functions {
     }
 
     public static Version getProgVersion() {
-        final ResourceBundle rb;
         String TOKEN_VERSION = "VERSION";
         try {
             ResourceBundle.clearCache();
-            rb = ResourceBundle.getBundle("version");
-            if (rb.containsKey(TOKEN_VERSION)) {
-                return new Version(rb.getString(TOKEN_VERSION));
+            if (rbversion.containsKey(TOKEN_VERSION)) {
+                return new Version(rbversion.getString(TOKEN_VERSION));
             }
         } catch (Exception e) {
             Log.errorLog(134679898, e);
@@ -174,13 +172,11 @@ public class Functions {
     
     @Deprecated
     public static String getBuildNr() {
-        final ResourceBundle rb;
         String TOKEN_VERSION = "VERSION";
         try {
             ResourceBundle.clearCache();
-            rb = ResourceBundle.getBundle("version");
-            if (rb.containsKey(TOKEN_VERSION)) {
-                return new Version(rb.getString(TOKEN_VERSION)).toString();
+            if (rbversion.containsKey(TOKEN_VERSION)) {
+                return new Version(rbversion.getString(TOKEN_VERSION)).toString();
             }
         } catch (Exception e) {
             Log.errorLog(134679898, e);

--- a/src/main/java/mSearch/tool/Functions.java
+++ b/src/main/java/mSearch/tool/Functions.java
@@ -29,7 +29,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 
 public class Functions {
 	
-	private static final ResourceBundle rbversion = ResourceBundle.getBundle("version");
+	private static final String RBVERSION = "version";
 
     public static String textLaenge(int max, String text, boolean mitte, boolean addVorne) {
         if (text.length() > max) {
@@ -148,8 +148,9 @@ public class Functions {
         String msg = "";
         try {
             ResourceBundle.clearCache();
-            if (rbversion.containsKey(propToken)) {
-                msg = rbversion.getString(propToken);
+            ResourceBundle rb = ResourceBundle.getBundle(RBVERSION);
+            if (rb.containsKey(propToken)) {
+                msg = rb.getString(propToken);
             }
         } catch (Exception e) {
             Log.errorLog(807293847, e);
@@ -161,8 +162,9 @@ public class Functions {
         String TOKEN_VERSION = "VERSION";
         try {
             ResourceBundle.clearCache();
-            if (rbversion.containsKey(TOKEN_VERSION)) {
-                return new Version(rbversion.getString(TOKEN_VERSION));
+            ResourceBundle rb = ResourceBundle.getBundle(RBVERSION);
+            if (rb.containsKey(TOKEN_VERSION)) {
+                return new Version(rb.getString(TOKEN_VERSION));
             }
         } catch (Exception e) {
             Log.errorLog(134679898, e);
@@ -175,8 +177,9 @@ public class Functions {
         String TOKEN_VERSION = "VERSION";
         try {
             ResourceBundle.clearCache();
-            if (rbversion.containsKey(TOKEN_VERSION)) {
-                return new Version(rbversion.getString(TOKEN_VERSION)).toString();
+            ResourceBundle rb = ResourceBundle.getBundle(RBVERSION);
+            if (rb.containsKey(TOKEN_VERSION)) {
+                return new Version(rb.getString(TOKEN_VERSION)).toString();
             }
         } catch (Exception e) {
             Log.errorLog(134679898, e);

--- a/src/main/java/mSearch/tool/Functions.java
+++ b/src/main/java/mSearch/tool/Functions.java
@@ -128,7 +128,7 @@ public class Functions {
     }
 
     public static String getProgVersionString() {
-        return " [Vers.: " + getBuildNr() + "]";
+        return " [Vers.: " + getProgVersion().toString() + "]";
     }
 
     public static String[] getJavaVersion() {
@@ -157,20 +157,35 @@ public class Functions {
         return msg;
     }
 
-    public static String getBuildNr() {
+    public static Version getProgVersion() {
         final ResourceBundle rb;
         String TOKEN_VERSION = "VERSION";
-        String msg = "0";
         try {
             ResourceBundle.clearCache();
             rb = ResourceBundle.getBundle("version");
             if (rb.containsKey(TOKEN_VERSION)) {
-                msg = rb.getString(TOKEN_VERSION);
+                return new Version(rb.getString(TOKEN_VERSION));
             }
         } catch (Exception e) {
             Log.errorLog(134679898, e);
         }
-        return msg;
+        return new Version("");
+    }
+    
+    @Deprecated
+    public static String getBuildNr() {
+        final ResourceBundle rb;
+        String TOKEN_VERSION = "VERSION";
+        try {
+            ResourceBundle.clearCache();
+            rb = ResourceBundle.getBundle("version");
+            if (rb.containsKey(TOKEN_VERSION)) {
+                return new Version(rb.getString(TOKEN_VERSION)).toString();
+            }
+        } catch (Exception e) {
+            Log.errorLog(134679898, e);
+        }
+        return new Version("").toString();
     }
 
     public static void unescape(DatenFilm film) {

--- a/src/main/java/mSearch/tool/Functions.java
+++ b/src/main/java/mSearch/tool/Functions.java
@@ -160,7 +160,7 @@ public class Functions {
     public static String getBuildNr() {
         final ResourceBundle rb;
         String TOKEN_VERSION = "VERSION";
-        String msg = "-1";
+        String msg = "0";
         try {
             ResourceBundle.clearCache();
             rb = ResourceBundle.getBundle("version");

--- a/src/main/java/mSearch/tool/Functions.java
+++ b/src/main/java/mSearch/tool/Functions.java
@@ -159,15 +159,12 @@ public class Functions {
 
     public static String getBuildNr() {
         final ResourceBundle rb;
-        String TOKEN_BUILD = "BUILD";
         String TOKEN_VERSION = "VERSION";
-        String msg = "0-0";
+        String msg = "-1";
         try {
             ResourceBundle.clearCache();
             rb = ResourceBundle.getBundle("version");
-            if (rb.containsKey(TOKEN_BUILD)) {
-                msg = rb.getString(TOKEN_BUILD);
-            } else if (rb.containsKey(TOKEN_VERSION)) {
+            if (rb.containsKey(TOKEN_VERSION)) {
                 msg = rb.getString(TOKEN_VERSION);
             }
         } catch (Exception e) {

--- a/src/main/java/mSearch/tool/Version.java
+++ b/src/main/java/mSearch/tool/Version.java
@@ -70,6 +70,7 @@ public class Version {
 	 * Gibt die Version als String zurück
 	 * @return String mit der Version
 	 */
+	@Override
 	public String toString() {
 		return String.format("%d.%d.%d", major, minor, patch);
 	}

--- a/src/main/java/mSearch/tool/Version.java
+++ b/src/main/java/mSearch/tool/Version.java
@@ -1,0 +1,92 @@
+package mSearch.tool;
+
+public class Version {
+	
+	private int major;
+	private int minor;
+	private int patch;
+	
+	public Version(int major, int minor, int patch) {
+		this.major = major;
+		this.minor = minor;
+		this.patch = patch;
+	}
+	
+	public Version(String versionsstring) {
+		String[] versions = versionsstring.split("\\.");
+		if(versions.length == 3) {
+			try {
+				major = Integer.parseInt(versions[0]);
+				minor = Integer.parseInt(versions[1]);
+				patch = Integer.parseInt(versions[2]);
+			} catch(NumberFormatException ex) {
+				Log.errorLog(12344564, ex, "Fehler beim Parsen der Version '" + versionsstring + "'.");
+				major = 0;
+				minor = 0;
+				patch = 0;
+			}
+		}
+	}
+	
+	public Version() {
+		major = 0;
+		minor = 0;
+		patch = 0;
+	}
+	
+	public int getMajor() {
+		return major;
+	}
+
+	public void setMajor(int major) {
+		this.major = major;
+	}
+
+	public int getMinor() {
+		return minor;
+	}
+
+	public void setMinor(int minor) {
+		this.minor = minor;
+	}
+
+	public int getPatch() {
+		return patch;
+	}
+
+	public void setPatch(int patch) {
+		this.patch = patch;
+	}
+	
+	/**
+	 * Gibt die Version als gewichtete Zahl zurück.
+	 * @return gewichtete Zahl als Integer
+	 */
+	public int toNumber() {
+		return major * 100 + minor * 10 + patch;
+	}
+	
+	/**
+	 * Gibt die Version als String zurück
+	 * @return String mit der Version
+	 */
+	public String toString() {
+		return String.format("%d.%d.%d", major, minor, patch);
+	}
+	
+	/**
+	 * Nimmt ein Objekt vom Typ Version an und vergleicht ihn mit sich selbst
+	 * @param a Versionsobjekt welches zum vergleich rangezogen werden soll
+	 * @return 1 Version a ist größer, 0 Versionen sind gleich oder -1 Version a ist kleiner
+	 */
+	public int compare(Version versionzwei) {
+		if(this.toNumber() < versionzwei.toNumber()) {
+			return 1;
+		} else if(this.toNumber() == versionzwei.toNumber()) {
+			return 0;
+		} else {
+			return -1;
+		}
+	}
+
+}


### PR DESCRIPTION
Es wird jetzt die Versionsnummer als Buildnummer ausgegeben.
Hardgecodete Versionsnummer für obsolet erklärt, da sie nun aus der version.properties geladen wird.
Betrifft Issue #86 